### PR TITLE
ArticleモデルとArticleテーブルを作成し、validationを追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,4 @@
+class Article < ApplicationRecord
+  validates :title, presence: true, uniqueness: { case_sensitive: false}
+  validates :content, presence: true
+end

--- a/db/migrate/20220728094434_create_articles.rb
+++ b/db/migrate/20220728094434_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_02_143446) do
+ActiveRecord::Schema.define(version: 2022_07_28_094434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "sample_articles", force: :cascade do |t|
     t.string "title"


### PR DESCRIPTION
## 概要

- bundle exec rails g model Article title:string content:textでArticleモデルの作成
- bundle exec rails db:migrateでDBへ反映しArticleテーブルの作成
- article.rbにvalidationの追加